### PR TITLE
castToBool method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
       "src/Keboola/Utils/stripInvalidUtf16.php",
       "src/Keboola/Utils/toAscii.php",
       "src/Keboola/Utils/sanitizeColumnName.php",
-      "src/Keboola/Utils/formatBytes.php"
+      "src/Keboola/Utils/formatBytes.php",
+      "src/Keboola/Utils/castToBool.php"
     ],
     "psr-0": {
       "Keboola\\Utils": "src/"

--- a/src/Keboola/Utils/castToBool.php
+++ b/src/Keboola/Utils/castToBool.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Keboola\Utils;
+
+/**
+ * @param mixed $castToBool
+ * @return bool
+ */
+function castToBool($castToBool)
+{
+    if (is_string($castToBool)) {
+        if ($castToBool === '1') {
+            return true;
+        }
+        if ($castToBool === 'true') {
+            return true;
+        }
+    }
+    if (is_int($castToBool) && $castToBool === 1) {
+        return true;
+    }
+
+    if (is_bool($castToBool) && $castToBool === true) {
+        return true;
+    }
+
+    return false;
+}

--- a/tests/Keboola/Utils/CastToBoolTest.php
+++ b/tests/Keboola/Utils/CastToBoolTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Keboola\Utils;
+
+use PHPUnit_Framework_TestCase;
+
+class CastToBoolTest extends PHPUnit_Framework_TestCase
+{
+    public function testCast()
+    {
+        self::assertTrue(castToBool(true));
+        self::assertTrue(castToBool('true'));
+        self::assertTrue(castToBool('1'));
+        self::assertTrue(castToBool(1));
+
+        self::assertFalse(castToBool(false));
+        self::assertFalse(castToBool('false'));
+        self::assertFalse(castToBool('0'));
+        self::assertFalse(castToBool(''));
+        self::assertFalse(castToBool('avsavasdasd'));
+        self::assertFalse(castToBool(0));
+        self::assertFalse(castToBool(2));
+        self::assertFalse(castToBool(1.0));
+        self::assertFalse(castToBool(1.1));
+        self::assertFalse(castToBool(132456));
+        self::assertFalse(castToBool([]));
+        self::assertFalse(castToBool(new \stdClass()));
+        self::assertFalse(castToBool(null));
+        self::assertFalse(castToBool(function () {
+        }));
+    }
+}


### PR DESCRIPTION
Chtěl bych vysunout `castToBool` pryč z KBC a použít ho i v SAPI importeru.